### PR TITLE
Support `fingerprint-pro-server-api-sdk` ^6.0

### DIFF
--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1727766285">
-  <project timestamp="1727766285">
+<coverage generated="1736019805">
+  <project timestamp="1736019805">
     <package name="ErayAydin\Fingerprint\Console">
       <file name="/home/runner/work/fingerprint-laravel/fingerprint-laravel/src/Console/AboutCommandRegistrar.php">
         <class name="ErayAydin\Fingerprint\Console\AboutCommandRegistrar" namespace="ErayAydin\Fingerprint\Console">
@@ -69,19 +69,18 @@
         <class name="ErayAydin\Fingerprint\Event" namespace="ErayAydin\Fingerprint">
           <metrics complexity="8" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="25" coveredstatements="25" elements="29" coveredelements="29"/>
         </class>
-        <line num="24" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="12"/>
-        <line num="29" type="stmt" count="12"/>
-        <line num="37" type="method" name="createFromEventResponse" visibility="public" complexity="1" crap="1" count="12"/>
-        <line num="39" type="stmt" count="12"/>
-        <line num="41" type="stmt" count="12"/>
+        <line num="25" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="12"/>
+        <line num="30" type="stmt" count="12"/>
+        <line num="38" type="method" name="createFromEventResponse" visibility="public" complexity="1" crap="1" count="12"/>
+        <line num="40" type="stmt" count="12"/>
         <line num="42" type="stmt" count="12"/>
         <line num="43" type="stmt" count="12"/>
         <line num="44" type="stmt" count="12"/>
         <line num="45" type="stmt" count="12"/>
         <line num="46" type="stmt" count="12"/>
-        <line num="55" type="method" name="createIdentification" visibility="private" complexity="1" crap="1" count="12"/>
-        <line num="57" type="stmt" count="12"/>
-        <line num="59" type="stmt" count="12"/>
+        <line num="47" type="stmt" count="12"/>
+        <line num="56" type="method" name="createIdentification" visibility="private" complexity="1" crap="1" count="12"/>
+        <line num="58" type="stmt" count="12"/>
         <line num="60" type="stmt" count="12"/>
         <line num="61" type="stmt" count="12"/>
         <line num="62" type="stmt" count="12"/>
@@ -91,14 +90,15 @@
         <line num="66" type="stmt" count="12"/>
         <line num="67" type="stmt" count="12"/>
         <line num="68" type="stmt" count="12"/>
-        <line num="77" type="method" name="getBotDResult" visibility="private" complexity="5" crap="5" count="12"/>
-        <line num="79" type="stmt" count="12"/>
-        <line num="80" type="stmt" count="10"/>
-        <line num="81" type="stmt" count="1"/>
-        <line num="82" type="stmt" count="1"/>
-        <line num="83" type="stmt" count="12"/>
+        <line num="69" type="stmt" count="12"/>
+        <line num="78" type="method" name="getBotDResult" visibility="private" complexity="5" crap="5" count="12"/>
+        <line num="80" type="stmt" count="12"/>
+        <line num="81" type="stmt" count="12"/>
+        <line num="82" type="stmt" count="2"/>
+        <line num="83" type="stmt" count="1"/>
         <line num="84" type="stmt" count="12"/>
-        <metrics loc="87" ncloc="58" classes="1" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="25" coveredstatements="25" elements="29" coveredelements="29"/>
+        <line num="85" type="stmt" count="12"/>
+        <metrics loc="88" ncloc="59" classes="1" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="25" coveredstatements="25" elements="29" coveredelements="29"/>
       </file>
       <file name="/home/runner/work/fingerprint-laravel/fingerprint-laravel/src/Fingerprint.php">
         <class name="ErayAydin\Fingerprint\Fingerprint" namespace="ErayAydin\Fingerprint">
@@ -362,6 +362,6 @@
         <metrics loc="50" ncloc="33" classes="1" methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="5" coveredstatements="5" elements="7" coveredelements="7"/>
       </file>
     </package>
-    <metrics files="25" loc="1074" ncloc="720" classes="21" methods="46" coveredmethods="42" conditionals="0" coveredconditionals="0" statements="164" coveredstatements="153" elements="210" coveredelements="195"/>
+    <metrics files="25" loc="1075" ncloc="721" classes="21" methods="46" coveredmethods="42" conditionals="0" coveredconditionals="0" statements="164" coveredstatements="153" elements="210" coveredelements="195"/>
   </project>
 </coverage>

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^8.2",
         "illuminate/support": "^11.24",
-        "fingerprint/fingerprint-pro-server-api-sdk": "^5.0",
+        "fingerprint/fingerprint-pro-server-api-sdk": "^6.0",
         "illuminate/http": "^11.24",
         "illuminate/routing": "^11.24"
     },

--- a/src/Event.php
+++ b/src/Event.php
@@ -4,9 +4,10 @@ namespace ErayAydin\Fingerprint;
 
 use DateTimeImmutable;
 use ErayAydin\Fingerprint\Enums\BotDResult;
-use Fingerprint\ServerAPI\Model\BotdDetectionResult;
-use Fingerprint\ServerAPI\Model\EventResponse;
-use Fingerprint\ServerAPI\Model\ProductsResponseIdentificationData;
+use Fingerprint\ServerAPI\Model\BotdBot;
+use Fingerprint\ServerAPI\Model\BotdBotResult;
+use Fingerprint\ServerAPI\Model\EventsGetResponse;
+use Fingerprint\ServerAPI\Model\Identification as FingerprintIdentification;
 
 /**
  * Class Event
@@ -31,16 +32,16 @@ class Event
     /**
      * Creates an Event instance from an EventResponse model.
      *
-     * @param  EventResponse  $model  The event response model.
+     * @param  EventsGetResponse  $model  The event response model.
      * @return self The created Event instance.
      */
-    public static function createFromEventResponse(EventResponse $model): self
+    public static function createFromEventResponse(EventsGetResponse $model): self
     {
         $products = $model->getProducts();
 
         return new self(
             self::createIdentification($products->getIdentification()->getData()),
-            self::getBotDResult($products->getBotd()->getData()->getBot()),
+            self::getBotDResult($products->getBotd()?->getData()?->getBot()),
             $products->getTor()?->getData()?->getResult(),
             $products->getVpn()->getData()->getResult(),
         );
@@ -49,10 +50,10 @@ class Event
     /**
      * Creates an Identification instance from a ProductsResponseIdentificationData model.
      *
-     * @param  ProductsResponseIdentificationData  $model  The identification data model.
+     * @param  FingerprintIdentification  $model  The identification data model.
      * @return Identification The created Identification instance.
      */
-    private static function createIdentification(ProductsResponseIdentificationData $model): Identification
+    private static function createIdentification(FingerprintIdentification $model): Identification
     {
         $timestamp = (int) ($model->getTimestamp() / 1000);
 
@@ -69,17 +70,17 @@ class Event
     }
 
     /**
-     * Gets the BotDResult from a BotdDetectionResult model.
+     * Gets the BotDResult from a BotdBot model.
      *
-     * @param  BotdDetectionResult  $botdDetectionResult  The bot detection result model.
-     * @return BotDResult|null The corresponding BotDResult or null if not exists in result model.
+     * @param  BotdBot|null  $botdBot  The bot detection result model.
+     * @return BotDResult The corresponding BotDResult or null if not exists in result model.
      */
-    private static function getBotDResult(BotdDetectionResult $botdDetectionResult): ?BotDResult
+    private static function getBotDResult(?BotdBot $botdBot): BotDResult
     {
-        return match ($botdDetectionResult->getResult()) {
-            'notDetected' => BotDResult::NotDetected,
-            'good' => BotDResult::Good,
-            'bad' => BotDResult::Bad,
+        return match ($botdBot?->getResult()) {
+            BotdBotResult::NOT_DETECTED => BotDResult::NotDetected,
+            BotdBotResult::GOOD => BotDResult::Good,
+            BotdBotResult::BAD => BotDResult::Bad,
             default => null,
         };
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,18 +7,19 @@ use DateTime;
 use ErayAydin\Fingerprint\Enums\BotBlockConfiguration;
 use ErayAydin\Fingerprint\Enums\TorBlockConfiguration;
 use ErayAydin\Fingerprint\FingerprintServiceProvider;
-use Fingerprint\ServerAPI\Model\BotdDetectionResult;
-use Fingerprint\ServerAPI\Model\BotdResult;
-use Fingerprint\ServerAPI\Model\Confidence;
-use Fingerprint\ServerAPI\Model\EventResponse;
-use Fingerprint\ServerAPI\Model\ProductsResponse;
-use Fingerprint\ServerAPI\Model\ProductsResponseBotd;
-use Fingerprint\ServerAPI\Model\ProductsResponseIdentification;
-use Fingerprint\ServerAPI\Model\ProductsResponseIdentificationData;
-use Fingerprint\ServerAPI\Model\SignalResponseTor;
-use Fingerprint\ServerAPI\Model\SignalResponseVpn;
-use Fingerprint\ServerAPI\Model\TorResult;
-use Fingerprint\ServerAPI\Model\VpnResult;
+use Fingerprint\ServerAPI\Model\Botd;
+use Fingerprint\ServerAPI\Model\BotdBot;
+use Fingerprint\ServerAPI\Model\BotdBotResult;
+use Fingerprint\ServerAPI\Model\EventsGetResponse;
+use Fingerprint\ServerAPI\Model\Identification;
+use Fingerprint\ServerAPI\Model\IdentificationConfidence;
+use Fingerprint\ServerAPI\Model\ProductBotd;
+use Fingerprint\ServerAPI\Model\ProductIdentification;
+use Fingerprint\ServerAPI\Model\Products;
+use Fingerprint\ServerAPI\Model\ProductTor;
+use Fingerprint\ServerAPI\Model\ProductVPN;
+use Fingerprint\ServerAPI\Model\Tor;
+use Fingerprint\ServerAPI\Model\VPN;
 use Illuminate\Contracts\Config\Repository;
 use Mockery;
 use Orchestra\Testbench\TestCase as Orchestra;
@@ -33,17 +34,17 @@ abstract class TestCase extends Orchestra
         string $ip = '127.0.0.1',
         float $confidence = 0.9,
         DateTime $time = new DateTime,
-        string $botDResult = 'notDetected',
+        BotdBotResult $botDResult = BotdBotResult::NOT_DETECTED,
         bool $isTor = false,
         bool $isVPN = false,
-    ): EventResponse {
-        $productsResponse = Mockery::mock(ProductsResponse::class);
+    ): EventsGetResponse {
+        $productsResponse = Mockery::mock(Products::class);
         $productsResponse->shouldReceive('getIdentification')->andReturn($this->getIdentificationMock($requestId, $visitorId, $incognito, $url, $ip, $confidence, $time));
         $productsResponse->shouldReceive('getBotd')->andReturn($this->getBotDResponseMock($botDResult));
         $productsResponse->shouldReceive('getTor')->andReturn($this->getTorResponseMock($isTor));
         $productsResponse->shouldReceive('getVpn')->andReturn($this->getVpnResponseMock($isVPN));
 
-        $eventResponse = Mockery::mock(EventResponse::class);
+        $eventResponse = Mockery::mock(EventsGetResponse::class);
         $eventResponse->shouldReceive('getProducts')->andReturn($productsResponse);
 
         return $eventResponse;
@@ -100,11 +101,11 @@ abstract class TestCase extends Orchestra
         string $ip,
         float $confidence,
         DateTime $time,
-    ): ProductsResponseIdentification {
-        $confidenceMock = Mockery::mock(Confidence::class);
+    ): ProductIdentification {
+        $confidenceMock = Mockery::mock(IdentificationConfidence::class);
         $confidenceMock->shouldReceive('getScore')->andReturn($confidence);
 
-        $identificationData = Mockery::mock(ProductsResponseIdentificationData::class);
+        $identificationData = Mockery::mock(Identification::class);
 
         $identificationData->shouldReceive('getTimestamp')->andReturn(1000000000000);
         $identificationData->shouldReceive('getRequestId')->andReturn($requestId);
@@ -115,44 +116,44 @@ abstract class TestCase extends Orchestra
         $identificationData->shouldReceive('getIp')->andReturn($ip);
         $identificationData->shouldReceive('getConfidence')->andReturn($confidenceMock);
 
-        $identification = Mockery::mock(ProductsResponseIdentification::class);
+        $identification = Mockery::mock(ProductIdentification::class);
 
         $identification->shouldReceive('getData')->andReturn($identificationData);
 
         return $identification;
     }
 
-    private function getBotDResponseMock(string $botDResult): ProductsResponseBotd
+    private function getBotDResponseMock(BotdBotResult $botDResult): ProductBotd
     {
-        $botDDetectionResult = Mockery::mock(BotdDetectionResult::class);
+        $botDDetectionResult = Mockery::mock(BotdBot::class);
         $botDDetectionResult->shouldReceive('getResult')->andReturn($botDResult);
 
-        $botDResultMock = Mockery::mock(BotdResult::class);
+        $botDResultMock = Mockery::mock(Botd::class);
         $botDResultMock->shouldReceive('getBot')->andReturn($botDDetectionResult);
 
-        $botDDetection = Mockery::mock(ProductsResponseBotd::class);
+        $botDDetection = Mockery::mock(ProductBotd::class);
         $botDDetection->shouldReceive('getData')->andReturn($botDResultMock);
 
         return $botDDetection;
     }
 
-    private function getTorResponseMock(bool $isTor): SignalResponseTor
+    private function getTorResponseMock(bool $isTor): ProductTor
     {
-        $torResult = Mockery::mock(TorResult::class);
+        $torResult = Mockery::mock(Tor::class);
         $torResult->shouldReceive('getResult')->andReturn($isTor);
 
-        $torResponse = Mockery::mock(SignalResponseTor::class);
+        $torResponse = Mockery::mock(ProductTor::class);
         $torResponse->shouldReceive('getData')->andReturn($torResult);
 
         return $torResponse;
     }
 
-    private function getVpnResponseMock(bool $isVPN): SignalResponseVpn
+    private function getVpnResponseMock(bool $isVPN): ProductVPN
     {
-        $vpnResult = Mockery::mock(VpnResult::class);
+        $vpnResult = Mockery::mock(VPN::class);
         $vpnResult->shouldReceive('getResult')->andReturn($isVPN);
 
-        $vpnResponse = Mockery::mock(SignalResponseVpn::class);
+        $vpnResponse = Mockery::mock(ProductVPN::class);
         $vpnResponse->shouldReceive('getData')->andReturn($vpnResult);
 
         return $vpnResponse;

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -2,10 +2,11 @@
 
 use ErayAydin\Fingerprint\Enums\BotDResult;
 use ErayAydin\Fingerprint\Event;
+use Fingerprint\ServerAPI\Model\BotdBotResult as FingerprintBotdBotResult;
 
 it('creates an Event instance from an EventResponse model', function () {
     $event = Event::createFromEventResponse(
-        $this->getEventResponseMock(incognito: true, botDResult: 'bad', isTor: true)
+        $this->getEventResponseMock(incognito: true, botDResult: FingerprintBotdBotResult::BAD, isTor: true)
     );
 
     expect($event->identification->requestId)->toBe('request-id')
@@ -21,7 +22,7 @@ it('creates an Event instance from an EventResponse model', function () {
 
 it('creates an Event instance with good bot', function () {
     $event = Event::createFromEventResponse(
-        $this->getEventResponseMock(incognito: true, botDResult: 'good', isTor: true)
+        $this->getEventResponseMock(incognito: true, botDResult: FingerprintBotdBotResult::GOOD, isTor: true)
     );
 
     expect($event->identification->requestId)->toBe('request-id')


### PR DESCRIPTION
Upgrades `fingerprint-pro-server-api-sdk` dependency to the `^6.0` version. Use new model names and fix mockery mock issues.